### PR TITLE
Fixes for JSON data and markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
 
 ## Configuration
 
- 1. Edit the config.conf file and enter your servers URLs and API keys for each server.  
+ 1. Edit the config.conf file and enter your servers URLs and API keys for each server.
+
  2. Add the profile name (case insensitive) and movie path for the Radarr instance the movies will be synced to:
 
-   ```ini
+```ini
     [radarrA]
     url = https://4k.example.com:443
     key = XXXXX
@@ -29,11 +30,11 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
     key = XXXXX
     profile = 1080p
     path = /data/Movies # if not given will use RadarrA path for each movie - may not be what you want!
-    ```
+ ```
 
  3. Or if you want to sync two Sonarr instances:
 
-    ```ini
+ ```ini
     [sonarrA]
     url = https://4k.example.com:443
     key = XXXXX
@@ -43,10 +44,11 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
     key = XXXXX
     profile = 1080p
     path = /data/Shows
+```
 
  4. Or if you want to sync two Lidarr instances:
- 5. 
-    ```ini
+
+ ```ini
     [lidarrA]
     url = https://lossless.example.com:443
     key = XXXXX
@@ -56,13 +58,13 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
     key = XXXXX
     profile = Standard
     path = /data/Music
-    ```
-    
-    **Note** you cannot have a mix of Radarr, Lidarr, or Sonarr config setups at the same time.
+ ```
 
- 6. Optional Configuration
- 
-    ```ini
+   **Note** you cannot have a mix of Radarr, Lidarr, or Sonarr config setups at the same time.
+
+ 5. Optional Configuration
+
+```ini
     [*arrA]
     url = http://127.0.0.1:8080
     key = XXXXX
@@ -81,36 +83,43 @@ Syncs two Radarr/Sonarr/Lidarr servers through the web API. Useful for syncing a
     path = /data/Movies
 
     [general]
-    sync_bidirectionally = 1 # sync from instance A to B **AND** instance B to A (default 0)
+    bidirectional = 1 # sync from instance A to B **AND** instance B to A (default 0)
     auto_search = 0 # search is automatically started on new content - disable by setting to 0 (default 1)
     skip_missing = 1 # content with missing files are skipped on sync - disable by setting to 0 (default 1) (Radarr only)
     monitor_new_content = 0 # set to 0 to never monitor new content synced or to 1 to always monitor new content synced (default 1)
     test_run = 1 # enable test mode - will run through sync program but will not actually sync content (default 0)
     sync_monitor = 1 # if set to 1 will sync if the content is monitored or not to instance B (default 0)
-    ```
+ ```
 
-    **Note** If `sync_bidirectionally` is set to `1`, then instance A will require either `profile_id` or `profile` AND `path` as well
+   **Note** If `bidirectional` is set to `1`, then instance A will require either `profile_id` or `profile` AND `path` as well
 
 ---
 
 ## Requirements
- * Python 3.6 or greater
- * 2 Radarr, Sonarr, or Lidarr servers
+
+* Python 3.6 or greater
+* 2 Radarr, Sonarr, or Lidarr servers
   
 ---
 
 ## How to Run
+
  1. install the needed python modules (you'll need pip or you can install the modules manually inside the `requirements.txt` file):
-    ```bash
+
+ ```bash
     pip install -r requirements.txt
-    ```
+ ```
+
  2. run this script directly or through a Cron:
-    ```bash
+
+ ```bash
     python index.py
-    ```
+ ```
 
 ---
+
 ## Docker Compose
+
 This script can run through a docker container with a set interval (default every 5 minutes)
 
 ```bash

--- a/config.conf
+++ b/config.conf
@@ -1,12 +1,21 @@
 # [radarrA]
 # url = https://example.com:443
 # key = FCKGW-RHQQ2-YXRKT-8TG6W-2B7Q8
+# profile = HD-1080p
+# profile_id = 4
+# path = /data/Movies
 
 # [radarrB]
 # url = http://127.0.0.1:8080
 # key = FCKGW-RHQQ2-YXRKT-8TG6W-2B7Q8
 # profile_id = 1
+# profile = Ultra-HD
 # path = /data/4k_Movies
 
 # [general]
-# sync_bidirectionally = 0
+# bidirectional = 0
+# log_level = 20
+# skip_missing = 0
+# auto_search = 1
+# monitor_new_content = 1
+# test_run = 0

--- a/index.py
+++ b/index.py
@@ -253,7 +253,7 @@ def sync_servers(instanceA_contents, instanceB_language_id, instanceB_contentIds
 
             # generate content from instance A to sync into instance B
             formatted_content = get_content_details(
-                content=dict(content),
+                content,
                 instance_path=instance_path,
                 instance_profile_id=instanceB_profile_id,
                 instance_url=instanceB_url,
@@ -266,7 +266,7 @@ def sync_servers(instanceA_contents, instanceB_language_id, instanceB_contentIds
             elif content_not_synced:
                 # sync content if not synced
                 logging.info(f'syncing content title "{title}"')
-                sync_response = instanceB_session.post(instanceB_content_url, data=json.dumps(formatted_content))
+                sync_response = instanceB_session.post(instanceB_content_url, json=formatted_content)
                 # check response and save content id for searching later on if success
                 if sync_response.status_code != 201 and sync_response.status_code != 200:
                     logger.error(f'server sync error for {title} - response: {sync_response.text}')
@@ -288,7 +288,7 @@ def sync_servers(instanceA_contents, instanceB_language_id, instanceB_contentIds
                     if matching_content_instanceB['monitored'] != content['monitored']:
                         matching_content_instanceB['monitored'] = content['monitored']
                         instanceB_content_url = get_content_put_path(instanceB_url, instanceB_key, matching_content_instanceB.get('id'))
-                        sync_response = instanceB_session.put(instanceB_content_url, data=json.dumps(matching_content_instanceB))
+                        sync_response = instanceB_session.put(instanceB_content_url, json=matching_content_instanceB)
                         # check response and save content id for searching later on if success
                         if sync_response.status_code != 202:
                             logger.error(f'server monitoring sync error for {title} - response: {sync_response.text}')


### PR DESCRIPTION
- `data=json.dumps()` output was not recognized as JSON by API - fixed by switching to `json=` param of session `POST`/`PUT` calls
- Markdown fixes as it was not formatting properly
- Adding proper param hint in conf for bidi functionality, i.e. `bidirectional` not `sync_bidirectionally`